### PR TITLE
Changed makeModules to return a broccoli MergedTree

### DIFF
--- a/examples/multiple/Brocfile.js
+++ b/examples/multiple/Brocfile.js
@@ -1,7 +1,8 @@
 var makeModules = require('../../index');
 
 module.exports = function(broccoli) {
-  return makeModules(broccoli.makeTree('lib'), {
+  var css = broccoli.makeTree('css');
+  var lib = makeModules(broccoli.makeTree('lib'), {
     main: 'main',
     packageName: 'arithmetic',
     global: 'Arithmetic',
@@ -9,5 +10,6 @@ module.exports = function(broccoli) {
       'jquery': 'jQuery'
     }
   });
+  return [lib, css];
 };
 

--- a/examples/multiple/css/multiple.css
+++ b/examples/multiple/css/multiple.css
@@ -1,0 +1,3 @@
+body {
+  font-family: "STIXGeneral";
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var broccoli = require('broccoli');
 var filterES6Modules = require('broccoli-es6-module-filter');
 var pickFiles = require('broccoli-static-compiler');
 var broconcat = require('broccoli-concat');
@@ -6,13 +7,17 @@ var globalize = require('./lib/global-transform');
 
 module.exports = function (tree, options) {
   validateOptions(options);
-  return [
+  return mergeTrees([
     makeDist('cjs')(transpileCJS(tree)),
     makeDist('amd')(transpileAMD(tree)),
     makeConcatDist('named-amd')(transpileNamedAMD(tree, options)),
     makeDist('globals')(transpileGlobals(tree, options))
-  ];
+  ]);
 };
+
+function mergeTrees(trees) {
+  return new broccoli.MergedTree(trees);
+}
 
 function validateOptions(options) {
   if (!options.main) throw new Error('You must provide a `main` option so I know which file is your entry script.');

--- a/test/expected/multiple.css
+++ b/test/expected/multiple.css
@@ -1,0 +1,3 @@
+body {
+  font-family: "STIXGeneral";
+}

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -11,18 +11,19 @@ describe('broccoli-dist-es6-module', function() {
       amd: cat('amd/main.js', 'amd/product.js', 'amd/sum.js'),
       cjs: cat('cjs/main.js', 'cjs/product.js', 'cjs/sum.js'),
       globals: cat('globals/main.js'),
-      namedAmd: cat('named-amd/main.js')
+      namedAmd: cat('named-amd/main.js'),
+      css: cat('multiple.css')
     };
     cd('../../../test/expected');
     var expected = {
       amd: cat('amd/main.js', 'amd/product.js', 'amd/sum.js'),
       cjs: cat('cjs/main.js', 'cjs/product.js', 'cjs/sum.js'),
       globals: cat('globals/main.js'),
-      namedAmd: cat('named-amd/main.js')
+      namedAmd: cat('named-amd/main.js'),
+      css: cat('multiple.css')
     };
     // sanity assertion, make sure all files aren't empty
     assert.ok(actual.amd.match(/define/));
     assert.deepEqual(actual, expected);
   });
 });
-


### PR DESCRIPTION
I was bashing my head off the desk trying to figure out why my Brocfile wasn't compiling. After some digging I realized that broccoli-dist-es6-module was returning an array of trees, not a tree. The fix was simple enough, turn the result into a merged tree. I feel like broccoli-dist-es6-module should do this itself to maintain a consistent experience for Broccoli users.

Let me know what you think. Also thanks a ton for all your work around this, it really helped me get up to speed a lot faster than I would have otherwise. I was a globals scumbag before ES6 tooling.
