### PR TITLE
Adds support for choosing which module systems to target

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Options
   exports to your global namespace, also the package that is returned in
   AMD with `require(['your-package-name'])`
 
+- `targets` - which module systems to build for _(defaults to all)_
+
 - `packageName` - _named-amd_, the name of your package
   `require(['your-package-name'])`;
 

--- a/index.js
+++ b/index.js
@@ -7,13 +7,21 @@ var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = function (tree, options) {
   validateOptions(options);
-  return mergeTrees([
-    makeDist('cjs')(transpileCJS(tree)),
-    makeDist('amd')(transpileAMD(tree)),
-    makeConcatDist('named-amd')(transpileNamedAMD(tree, options)),
-    makeDist('globals')(transpileGlobals(tree, options))
-  ]);
+
+  var targets = options.targets || [ 'cjs', 'amd', 'named-amd', 'globals' ];
+  var trees = [];
+
+  contains(targets, 'cjs')       && trees.push(makeDist('cjs')(transpileCJS(tree))),
+  contains(targets, 'amd')       && trees.push(makeDist('amd')(transpileAMD(tree))),
+  contains(targets, 'named-amd') && trees.push(makeConcatDist('named-amd')(transpileNamedAMD(tree, options))),
+  contains(targets, 'globals')   && trees.push(makeDist('globals')(transpileGlobals(tree, options)))
+
+  return mergeTrees(trees);
 };
+
+function contains(arr, element) {
+  return arr.indexOf(element) !== -1;
+}
 
 function validateOptions(options) {
   if (!options.main) throw new Error('You must provide a `main` option so I know which file is your entry script.');

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1,5 +1,7 @@
 //var assert = require('assert');
 var assert = require('chai').assert;
+var ES6Module = require('../index');
+
 require('shelljs/global');
 
 describe('broccoli-dist-es6-module', function() {
@@ -27,6 +29,26 @@ describe('broccoli-dist-es6-module', function() {
     assert.equal(actual.cjs, expected.cjs);
     assert.equal(actual.globals, expected.globals);
     assert.equal(actual.namedAmd, expected.namedAmd);
+  });
+  it('only builds for targets specified', function() {
+    var output = ES6Module('.', {
+      global: 'Test.Package',
+      packageName: 'test-package',
+      main: 'index',
+      targets: [ 'amd', 'cjs' ]
+    });
+
+    assert.equal(output.inputTrees.length, 2);
+    assert.deepEqual(output.inputTrees.map(function(tree) { return tree.options.destDir; }), [ 'cjs', 'amd']);
+  });
+  it('will build all targets when none are specified', function() {
+    var output = ES6Module('.', {
+      global: 'Test.Package',
+      packageName: 'test-package',
+      main: 'index',
+    });
+
+    assert.equal(output.inputTrees.length, 4);
   });
 });
 


### PR DESCRIPTION
There are times, particularly when targeting globals, when different module systems require slightly different implementations. To facilitate this, I added support for specifying different module systems.

Example:

``` js
var moduleTree = compile(srcTee, {
  global: 'Test.Package',
  packageName: 'test-package',
  main: 'main',
  targets: [ 'amd', 'cjs', 'named-amd' ]
});

var globalTree = compile(srcTree, {
  global: 'Test.Package',
  packageName: 'test-package',
  main: 'global-main',
  targets: [ 'globals' ]
});
```
