### PR TITLE
Improve example instructions

### DIFF
--- a/examples/multiple/README.md
+++ b/examples/multiple/README.md
@@ -1,4 +1,13 @@
-To run this example:
+To run this example, first make sure you have Broccoli installed:
+
+```sh
+$ npm install -g broccoli-cli
+```
+
+Next, make sure you have run `npm install` in the root of this repository
+(i.e., the `/broccoli-dist-es6-module` directory).
+
+Now you are ready to run the following commands inside this example directory:
 
 ```sh
 $ npm install


### PR DESCRIPTION
I tried to run the commands in the example's README without first running `npm install` inside the root directory and got an error. It's a n00b mistake, but a frustrating one. Let's make that initial experience smoother.

For reference, here's the error I got:

```
$ broccoli build dist

module.js:340
    throw err;
          ^
Error: Cannot find module 'broccoli-es6-module-filter'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/strathmeyer/Development/broccoli-dist-es6-module/index.js:1:86)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
